### PR TITLE
Optimize work for reviewing PR with gh-dash and octo

### DIFF
--- a/gh-dash.yml
+++ b/gh-dash.yml
@@ -1,0 +1,65 @@
+prSections:
+- title: My Pull Requests
+  filters: is:open author:@me
+- title: Needs My Review
+  filters: is:open review-requested:@me
+- title: Involved
+  filters: is:open involves:@me -author:@me
+issuesSections:
+- title: My Issues
+  filters: is:open author:@me
+- title: Assigned
+  filters: is:open assignee:@me
+- title: Involved
+  filters: is:open involves:@me -author:@me
+defaults:
+  preview:
+    open: true
+    width: 50
+  prsLimit: 20
+  issuesLimit: 20
+  view: prs
+  layout:
+    prs:
+      updatedAt:
+        width: 7
+      repo:
+        width: 15
+      author:
+        width: 15
+      assignees:
+        width: 20
+        hidden: true
+      base:
+        width: 15
+        hidden: true
+      lines:
+        width: 16
+    issues:
+      updatedAt:
+        width: 7
+      repo:
+        width: 15
+      creator:
+        width: 10
+      assignees:
+        width: 20
+        hidden: true
+  refetchIntervalMinutes: 30
+keybindings:
+  issues: []
+  prs:
+    - key: C
+      command: |-
+        tmux new-session -d -c {{.RepoPath}} -s {{.RepoName}}#{{.PrNumber}} 'gh pr checkout {{.PrNumber}} && nvim -c ":Octo pr edit {{.PrNumber}}"' \; attach
+    - key: d
+      command: |-
+        tmux new-session -d -c {{.RepoPath}} -s {{.RepoName}}#{{.PrNumber}} 'gh pr checkout {{.PrNumber}} && nvim -c ":DiffviewOpen origin/$(gh pr status --json baseRefName -q '.currentBranch.baseRefName')...{{.HeadRefName}}"' \; attach
+repoPaths:
+  datahaikuninja/*: "$HOME/ghq/mine/github.com/datahaikuninja/*"
+theme:
+  ui:
+    table:
+      showSeparator: true
+pager:
+  diff: ""

--- a/init.lua
+++ b/init.lua
@@ -33,6 +33,7 @@ require("lazy").setup({
   "windwp/nvim-autopairs",
   "nvim-lua/plenary.nvim",
   "lewis6991/gitsigns.nvim",
+  "sindrets/diffview.nvim",
   { "j-hui/fidget.nvim", tag = "legacy" },
   {
     "nvim-telescope/telescope.nvim",
@@ -658,6 +659,8 @@ require("gitsigns").setup({
     map("n", "<leader>tb", gs.toggle_current_line_blame)
   end,
 })
+
+require("diffview").setup()
 
 -- github copilot
 require("copilot").setup({

--- a/setup.md
+++ b/setup.md
@@ -84,6 +84,9 @@ ln -snvf ~/ghq/mine/github.com/datahaikuninja/dotfiles/lazygit.yml config.yml
 cd ~/.config/gh-dash/
 ln -snvf ~/ghq/mine/github.com/datahaikuninja/dotfiles/gh-dash.yml config.yml
 
+# tmux
+mkdir -p ~/.config/tmux/
+ln -snvf ~/ghq/mine/github.com/datahaikuninja/dotfiles/tmux.conf tmux.conf
 ```
 
 ## asdf

--- a/setup.md
+++ b/setup.md
@@ -80,6 +80,10 @@ open /Applications/WezTerm.app
 cd ~/Library/Application\ Support/lazygit
 ln -snvf ~/ghq/mine/github.com/datahaikuninja/dotfiles/lazygit.yml config.yml
 
+# gh-dash
+cd ~/.config/gh-dash/
+ln -snvf ~/ghq/mine/github.com/datahaikuninja/dotfiles/gh-dash.yml config.yml
+
 ```
 
 ## asdf

--- a/tmux.conf
+++ b/tmux.conf
@@ -1,0 +1,12 @@
+# change color for status-line background color and char color
+setw -g status-style fg=colour255,bg=colour234
+
+# disable status left
+set -g status-left ""
+
+# disable status right
+set -g status-right ""
+
+# change format of window-status
+setw -g window-status-current-format '#[bg=colour233,fg=colour2] #I #W '
+setw -g window-status-current-format '#[bg=colour233,fg=colour2]#{?client_prefix,#[fg=colour3],} #I #W '

--- a/tmux.conf
+++ b/tmux.conf
@@ -1,5 +1,5 @@
 # change color for status-line background color and char color
-setw -g status-style fg=colour255,bg=colour234
+setw -g status-style fg=colour255,bg=colour235
 
 # disable status left
 set -g status-left ""
@@ -8,5 +8,5 @@ set -g status-left ""
 set -g status-right ""
 
 # change format of window-status
-setw -g window-status-current-format '#[bg=colour233,fg=colour2] #I #W '
-setw -g window-status-current-format '#[bg=colour233,fg=colour2]#{?client_prefix,#[fg=colour3],} #I #W '
+setw -g window-status-current-format '#[bg=colour2,fg=colour255] #I #W '
+setw -g window-status-current-format '#[bg=colour2,fg=colour255]#{?client_prefix,#[bg=colour3],} #I #W '


### PR DESCRIPTION
GitHub にホストされているリポジトリにおける Pull Request のレビュー作業を効率化したい。
本PRで提出するコミットにより以下が可能になる。
1. gh-dash コマンドで自分がreviewerにアサインされたPRやメンションされたPRをダッシュボードで確認する
2. PR を選択して `d` key で base branch との差分を確認する。このとき、tmux で新しいセッションを起動し、このセッションでNeovim の diffview プラグインを利用してサイドビューで視覚的に分かりやすく差分を確認できるようにした。
3. あるいは、PRを選択して、`C` key でPRのレビューを実施する。このとき、tmux で新しいセッションを起動し、このセッションでNeovim の octo プラグインを利用して、差分確認からレビューコメントの提出まで、Neovim内で実施できるようにした。

なお、Neovim を `:qa!` 等で終了すると、gh-dash のダッシュボード画面に戻る。tmux のセッションは Neovim と共に終了する。

hoge