### PR TITLE
wip: keymap to move tab

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -160,6 +160,8 @@ vim.keymap.set("c", "<C-n>", "<Down>", { noremap = true })
 vim.keymap.set("n", "<ESC><ESC>", "<cmd>nohlsearch<CR>", { noremap = true })
 vim.keymap.set("t", "<ESC>", "<C-\\><C-n>", { noremap = true })
 
+vim.keymap.set("n", "<C-t>", "<cmd>tabprevious<CR>", { silent = true })
+
 -- use hard tabs for golang
 vim.api.nvim_create_autocmd("FileType", {
   pattern = "*.go",


### PR DESCRIPTION
ToggleTerm や lazygit の画面をタブに表示するようにしたので、頻繁に`:tabprevious`と`:tabnext`を使用するようになり、毎回コマンドを入力するのが面倒になったので、normal mode で `CTRL+t`でタブを順番に移動できるようにした。３つ以上のタブを常に起動して利用することは想定していないので暫定的にはこのキーマップの運用でもいいと思っているが、よりよい案を思いついたら変える。