### PR TITLE
Fix/lspsaga keybind and gh dash repo path

### DIFF
--- a/gh-dash.yml
+++ b/gh-dash.yml
@@ -71,6 +71,7 @@ keybindings:
 repoPaths:
   datahaikuninja/*: "$HOME/ghq/mine/github.com/datahaikuninja/*"
   adtech-tver/*: "$HOME/ghq/github.com/adtech-tver/*"
+  sankantsu/*: "$HOME/ghq/default/github.com/sankantsu/*"
 theme:
   ui:
     table:

--- a/init.lua
+++ b/init.lua
@@ -325,7 +325,9 @@ local on_attach = function(client, bufnr)
   set("n", "gn", "<cmd>Lspsaga rename<CR>")
   -- set("n", "ma", "<cmd>lua vim.lsp.buf.code_action()<CR>") -- replace by actions-preview
   set("n", "gr", "<cmd>Lspsaga finder<CR>")
-  set("n", "<space>e", "<cmd>Lspsaga show_line_diagnostics<CR>")
+  set("n", "<space>l", "<cmd>Lspsaga show_line_diagnostics<CR>")
+  set("n", "<space>b", "<cmd>Lspsaga show_buf_diagnostics<CR>")
+  set("n", "<space>w", "<cmd>Lspsaga show_workspace_diagnostics ++normal<CR>")
   set("n", "[d", "<cmd>Lspsaga diagnostic_jump_prev<CR>")
   set("n", "]d", "<cmd>Lspsaga diagnostic_jump_next<CR>")
 end


### PR DESCRIPTION
- e444e31baa87693321da50c1a8ef42105a2a05fa
  - 以下で作業するようになったので gh-dash の repoPath に追加
  - https://github.com/sankantsu/mikanos-rs-loader

- 714a417be44b40a626f61007aaa1af98e4f6c291
  - Lspsaga show_line_diagnostics のキーバインドを修正
  - Lspsaga show_(buffer|workspace)_diagnostics のキーバインドを追加