### PR TITLE
feat: configure Language Server with vim.lsp.config API introduced by Neovim v0.11

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -1,2 +1,3 @@
 require("core")
 require("plugins")
+require("config")

--- a/nvim/lua/config/init.lua
+++ b/nvim/lua/config/init.lua
@@ -1,0 +1,1 @@
+require("config.lsp")

--- a/nvim/lua/config/lsp.lua
+++ b/nvim/lua/config/lsp.lua
@@ -1,0 +1,121 @@
+vim.diagnostic.config({
+  virtual_text = false,
+  severity_sort = true,
+})
+
+vim.lsp.set_log_level(vim.log.levels.ERROR)
+
+-- config for all Language Server
+vim.lsp.config("*", {
+  on_attach = function(client, bufnr)
+    -- keymaps for lsp
+    local set = vim.keymap.set
+    set("n", "gd", "<cmd>Lspsaga peek_definition<CR>")
+    set("n", "gK", "<cmd>Lspsaga hover_doc<CR>")
+    -- set("n", "<C-m>", "<cmd>lua vim.lsp.buf.signature_help()<CR>")
+    set("n", "gt", "<cmd>Lspsaga peek_type_definition<CR>")
+    set("n", "gn", "<cmd>Lspsaga rename<CR>")
+    -- set("n", "ma", "<cmd>lua vim.lsp.buf.code_action()<CR>") -- replace by actions-preview
+    set("n", "gr", "<cmd>Lspsaga finder<CR>")
+    set("n", "<space>l", "<cmd>Lspsaga show_line_diagnostics<CR>")
+    set("n", "<space>b", "<cmd>Lspsaga show_buf_diagnostics<CR>")
+    set("n", "<space>w", "<cmd>Lspsaga show_workspace_diagnostics ++normal<CR>")
+    set("n", "[d", "<cmd>Lspsaga diagnostic_jump_prev<CR>")
+    set("n", "]d", "<cmd>Lspsaga diagnostic_jump_next<CR>")
+  end,
+  capabilities = require("cmp_nvim_lsp").default_capabilities(),
+})
+
+-- config for pylsp
+vim.lsp.config("pylsp", {
+  settings = {
+    pylsp = {
+      configurationSources = { "flake8", "pycodestyle" },
+      plugins = {
+        pycodestyle = { enabled = false },
+        flake8 = {
+          enabled = true,
+          maxLineLength = 120,
+        },
+      },
+    },
+  },
+})
+
+-- config for gopls
+vim.lsp.config("gopls", {
+  settings = {
+    gopls = {
+      analyses = {
+        unusedparams = true,
+      },
+      staticcheck = true,
+      gofumpt = false,
+    },
+  },
+})
+
+-- config for rust-analyzer
+vim.lsp.config("rust_analyzer", {
+  settings = {
+    ["rust-analyzer"] = {
+      check = {
+        -- rust-analyzer.check.command
+        -- see: https://github.com/rust-lang/rust-analyzer/blob/master/docs/user/generated_config.adoc
+        command = "clippy",
+      },
+    },
+  },
+})
+
+-- go-fmt on save
+-- https://github.com/golang/tools/blob/master/gopls/doc/vim.md#neovim-imports
+vim.api.nvim_create_autocmd("BufWritePre", {
+  pattern = "*.go",
+  callback = function()
+    local params = vim.lsp.util.make_range_params()
+    params.context = { only = { "source.organizeImports" } }
+    -- buf_request_sync defaults to a 1000ms timeout. Depending on your
+    -- machine and codebase, you may want longer. Add an additional
+    -- argument after params if you find that you have to write the file
+    -- twice for changes to be saved.
+    -- E.g., vim.lsp.buf_request_sync(0, "textDocument/codeAction", params, 3000)
+    local result = vim.lsp.buf_request_sync(0, "textDocument/codeAction", params)
+    for cid, res in pairs(result or {}) do
+      for _, r in pairs(res.result or {}) do
+        if r.edit then
+          local enc = (vim.lsp.get_client_by_id(cid) or {}).offset_encoding or "utf-16"
+          vim.lsp.util.apply_workspace_edit(r.edit, enc)
+        end
+      end
+    end
+    vim.lsp.buf.format({ async = false })
+  end,
+})
+
+-- rustfmt on save
+-- see: https://minerva.mamansoft.net/Notes/%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E3%81%8C%E4%BF%9D%E5%AD%98%E3%81%95%E3%82%8C%E3%81%9F%E3%82%89%E8%87%AA%E5%8B%95%E3%83%95%E3%82%A9%E3%83%BC%E3%83%9E%E3%83%83%E3%83%88+(nvim-lspconfig)
+
+vim.api.nvim_create_autocmd("LspAttach", {
+  callback = function(event)
+    vim.api.nvim_create_autocmd("BufWritePre", {
+      pattern = { "*.rs" },
+      callback = function()
+        vim.lsp.buf.format({
+          buffer = event.buf,
+          async = false,
+        })
+      end,
+    })
+  end,
+})
+
+vim.api.nvim_create_autocmd("BufWritePre", {
+  pattern = "*.lua",
+  callback = function()
+    vim.lsp.buf.format()
+  end,
+})
+
+-- enable all Language Server installed by mason
+vim.lsp.enable(require("mason-lspconfig").get_installed_servers())

--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -24,10 +24,10 @@ return {
           documentation = cmp.config.window.bordered(),
         },
         sources = {
-          { name = "copilot", keyword_length = 2 },
+          { name = "copilot",                keyword_length = 2 },
           { name = "nvim_lsp" },
           { name = "vsnip" },
-          { name = "buffer", keyword_length = 3 },
+          { name = "buffer",                 keyword_length = 3 },
           { name = "path" },
           { name = "nvim_lsp_signature_help" },
         },
@@ -87,148 +87,19 @@ return {
       })
     end,
   },
-  { "williamboman/mason.nvim", build = ":MasonUpdate", opts = {} },
+  { "williamboman/mason.nvim",   build = ":MasonUpdate", opts = {} },
   {
     "williamboman/mason-lspconfig.nvim",
-    config = function()
-      require("mason-lspconfig").setup({
-        ensure_installed = {
-          "lua_ls",
-          "pylsp",
-          "terraformls",
-          "tflint",
-          "gopls",
-          "rust_analyzer",
-        },
-      })
-      local on_attach = function(client, bufnr)
-        -- keymaps for lsp
-        local set = vim.keymap.set
-        set("n", "gd", "<cmd>Lspsaga peek_definition<CR>")
-        set("n", "gK", "<cmd>Lspsaga hover_doc<CR>")
-        -- set("n", "<C-m>", "<cmd>lua vim.lsp.buf.signature_help()<CR>")
-        set("n", "gt", "<cmd>Lspsaga peek_type_definition<CR>")
-        set("n", "gn", "<cmd>Lspsaga rename<CR>")
-        -- set("n", "ma", "<cmd>lua vim.lsp.buf.code_action()<CR>") -- replace by actions-preview
-        set("n", "gr", "<cmd>Lspsaga finder<CR>")
-        set("n", "<space>l", "<cmd>Lspsaga show_line_diagnostics<CR>")
-        set("n", "<space>b", "<cmd>Lspsaga show_buf_diagnostics<CR>")
-        set("n", "<space>w", "<cmd>Lspsaga show_workspace_diagnostics ++normal<CR>")
-        set("n", "[d", "<cmd>Lspsaga diagnostic_jump_prev<CR>")
-        set("n", "]d", "<cmd>Lspsaga diagnostic_jump_next<CR>")
-      end
-      local capabilities = require("cmp_nvim_lsp").default_capabilities()
-      require("mason-lspconfig").setup_handlers({
-        function(server_name)
-          require("lspconfig")[server_name].setup({
-            on_attach = on_attach,
-            capabilities = capabilities,
-          })
-        end,
-        ["pylsp"] = function()
-          require("lspconfig").pylsp.setup({
-            on_attach = on_attach,
-            capabilities = capabilities,
-            settings = {
-              pylsp = {
-                configurationSources = { "flake8", "pycodestyle" },
-                plugins = {
-                  pycodestyle = { enabled = false },
-                  flake8 = {
-                    enabled = true,
-                    maxLineLength = 120,
-                  },
-                },
-              },
-            },
-          })
-        end,
-        ["gopls"] = function()
-          require("lspconfig").gopls.setup({
-            on_attach = on_attach,
-            capabilities = capabilities,
-            settings = {
-              gopls = {
-                analyses = {
-                  unusedparams = true,
-                },
-                staticcheck = true,
-                gofumpt = false,
-              },
-            },
-          })
-        end,
-        -- see:
-        -- https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#rust_analyzer
-        -- https://github.com/rust-lang/rust-analyzer/blob/master/docs/user/generated_config.adoc
-        -- https://rust-analyzer.github.io/manual.html#nvim-lsp
-        ["rust_analyzer"] = function()
-          require("lspconfig").rust_analyzer.setup({
-            on_attach = on_attach,
-            capabilities = capabilities,
-            settings = {
-              ["rust-analyzer"] = {
-                check = {
-                  -- rust-analyzer.check.command
-                  -- see: https://github.com/rust-lang/rust-analyzer/blob/master/docs/user/generated_config.adoc
-                  command = "clippy",
-                },
-              },
-            },
-          })
-        end,
-      })
-      vim.diagnostic.config({ virtual_text = false, severity_sort = true })
-      -- avoid increasing LSP log filesize
-      vim.lsp.set_log_level(vim.log.levels.ERROR)
-
-      -- go-fmt on save
-      -- https://github.com/golang/tools/blob/master/gopls/doc/vim.md#neovim-imports
-      vim.api.nvim_create_autocmd("BufWritePre", {
-        pattern = "*.go",
-        callback = function()
-          local params = vim.lsp.util.make_range_params()
-          params.context = { only = { "source.organizeImports" } }
-          -- buf_request_sync defaults to a 1000ms timeout. Depending on your
-          -- machine and codebase, you may want longer. Add an additional
-          -- argument after params if you find that you have to write the file
-          -- twice for changes to be saved.
-          -- E.g., vim.lsp.buf_request_sync(0, "textDocument/codeAction", params, 3000)
-          local result = vim.lsp.buf_request_sync(0, "textDocument/codeAction", params)
-          for cid, res in pairs(result or {}) do
-            for _, r in pairs(res.result or {}) do
-              if r.edit then
-                local enc = (vim.lsp.get_client_by_id(cid) or {}).offset_encoding or "utf-16"
-                vim.lsp.util.apply_workspace_edit(r.edit, enc)
-              end
-            end
-          end
-          vim.lsp.buf.format({ async = false })
-        end,
-      })
-
-      -- see: https://minerva.mamansoft.net/Notes/%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E3%81%8C%E4%BF%9D%E5%AD%98%E3%81%95%E3%82%8C%E3%81%9F%E3%82%89%E8%87%AA%E5%8B%95%E3%83%95%E3%82%A9%E3%83%BC%E3%83%9E%E3%83%83%E3%83%88+(nvim-lspconfig)
-      vim.api.nvim_create_autocmd("LspAttach", {
-        callback = function(event)
-          vim.api.nvim_create_autocmd("BufWritePre", {
-            pattern = { "*.rs" },
-            callback = function()
-              vim.lsp.buf.format({
-                buffer = event.buf,
-                async = false,
-              })
-            end,
-          })
-        end,
-      })
-
-      vim.api.nvim_create_autocmd("BufWritePre", {
-        pattern = "*.lua",
-        callback = function()
-          vim.lsp.buf.format()
-        end,
-      })
-    end,
+    opts = {
+      ensure_installed = {
+        "lua_ls",
+        "pylsp",
+        "terraformls",
+        "tflint",
+        "gopls",
+        "rust_analyzer",
+      },
+    },
   },
   {
     "nvimtools/none-ls.nvim",
@@ -259,5 +130,5 @@ return {
       lightbulb = { sign = false, virtual_text = false },
     },
   },
-  { "maxandron/goplements.nvim", ft = "go", opts = {} },
+  { "maxandron/goplements.nvim", ft = "go",              opts = {} },
 }


### PR DESCRIPTION
This pull request refactors and streamlines the Neovim configuration for Language Server Protocol (LSP) support. The changes include modularizing the LSP configuration, moving it to a dedicated `config` module, and simplifying the `plugins/lsp.lua` file by transferring detailed configurations to `config/lsp.lua`. Below are the most important changes grouped by theme:

### Modularization of LSP Configuration:
* Added a new `config` module by requiring `config.lsp` in `nvim/init.lua` and `nvim/lua/config/init.lua`. This centralizes LSP-related configurations into a single file for better maintainability. (`[[1]](diffhunk://#diff-8cb544b4cf90adf36ca7c145b5bf73c08a6e56624099821a29e0653d0dfa6099R3)`, `[[2]](diffhunk://#diff-47583525612e5357cc76f97b78ee4f42bb50cd3199abe0eec99d60b86d672ce1R1)`)

### Detailed LSP Settings:
* Created `nvim/lua/config/lsp.lua` to house all LSP configurations, including:
  - General LSP settings such as disabling virtual text for diagnostics and setting the log level to `ERROR`.
  - Key mappings for LSP features like definition preview, hover documentation, and diagnostics navigation.
  - Server-specific configurations for `pylsp`, `gopls`, and `rust_analyzer`, including settings for linting, formatting, and static analysis. (`[nvim/lua/config/lsp.luaR1-R121](diffhunk://#diff-8f2f4684243c89829c4b2e0b1cfe1872b49f125eabb67868323f5f9848835c98R1-R121)`)

### File Formatting on Save:
* Added auto-formatting hooks for specific file types:
  - `*.go` files: Organizes imports and formats the code using `gopls`.
  - `*.rs` files: Formats the code using `rustfmt`.
  - `*.lua` files: Formats the code using the default LSP formatter. (`[nvim/lua/config/lsp.luaR1-R121](diffhunk://#diff-8f2f4684243c89829c4b2e0b1cfe1872b49f125eabb67868323f5f9848835c98R1-R121)`)

### Simplification of Plugin Configuration:
* Refactored `nvim/lua/plugins/lsp.lua`:
  - Replaced the inline LSP configuration with `opts` for `mason-lspconfig.nvim`, delegating setup responsibilities to the new `config/lsp.lua`.
  - Removed redundant and verbose setup code, improving readability and modularity. (`[[1]](diffhunk://#diff-88c222132debac891ac0380c464d8b88a9cd8e1751503f6c0f0f630064c2ef86L93-R93)`, `[[2]](diffhunk://#diff-88c222132debac891ac0380c464d8b88a9cd8e1751503f6c0f0f630064c2ef86L103-L232)`)