### PR TITLE
feat: change font to BerkeleyMono

### DIFF
--- a/wezterm.lua
+++ b/wezterm.lua
@@ -36,14 +36,16 @@ config.window_background_opacity = 0.8
 -- fonts
 config.font = wezterm.font_with_fallback({
   {
-    family = "JetBrains Mono",
-    --harfbuzz_features = { "calt=0", "clig=0", "liga=0" },
-    weight = "Medium",
-    stretch = "Normal",
-    style = "Normal",
+    --family = "JetBrains Mono",
+    family = "Berkeley Mono",
+    -- harfbuzz_features = { "calt=0", "clig=0", "liga=0" },
+    weight = "Regular",
+    -- stretch = "Normal",
+    -- style = "Normal",
   },
   {
-    family = "HackGen",
+    --family = "HackGen",
+    family = "BerkeleyMono",
     weight = "Regular",
   },
 })


### PR DESCRIPTION
This pull request updates the font configuration in the `wezterm.lua` file to use a different font family and simplifies the font settings by commenting out unused attributes.

Font configuration updates:

* Changed the primary font family from `JetBrains Mono` to `Berkeley Mono` and commented out the previous font family.
* Updated the fallback font family from `HackGen` to `BerkeleyMono` and commented out the previous fallback font family.
* Simplified font attributes by commenting out `stretch` and `style` properties and changing the weight of the primary font to "Regular".